### PR TITLE
feat: empty pool address handling

### DIFF
--- a/src/JBBuybackHook.sol
+++ b/src/JBBuybackHook.sol
@@ -560,12 +560,15 @@ contract JBBuybackHook is ERC165, JBPermissioned, IJBBuybackHook {
         // Get a reference to the pool that'll be used to make the swap.
         IUniswapV3Pool pool = poolOf[projectId][address(terminalToken)];
 
-        // Make sure the pool exists.
+        // Make sure the pool exists, if not, return an empty quote.
+        if (address(pool).code.length == 0) return 0;
+
+        // If there is a contract at the address, try to get the pool's slot 0.
         try pool.slot0() returns (uint160, int24, uint16, uint16, uint16, uint8, bool unlocked) {
             // If the pool hasn't been initialized, return an empty quote.
             if (!unlocked) return 0;
         } catch {
-            // If the address is invalid, or if the pool has not been deployed yet, return an empty quote.
+            // If the address is invalid, return an empty quote.
             return 0;
         }
 

--- a/test/Unit.t.sol
+++ b/test/Unit.t.sol
@@ -322,6 +322,30 @@ contract Test_BuybackHook_Unit is Test {
         assertEq(weightReturned, tokenCount);
     }
 
+    /// @notice Test `beforePayRecordedWith` with a TWAP but a non-deployed pool, which should lead to the payment minting
+    /// from the terminal.
+    function test_beforePayRecordedContext_useTwapNonDeployedPool(uint256 tokenCount) public {
+        tokenCount = bound(tokenCount, 1, type(uint120).max);
+
+        // Set the relevant context.
+        beforePayRecordedContext.weight = tokenCount;
+        beforePayRecordedContext.metadata = "";
+
+        // Return values to catch:
+        JBPayHookSpecification[] memory specificationsReturned;
+        uint256 weightReturned;
+
+        // Test: call `beforePayRecordedWith` - notice we don't mock the pool, as the address should remain empty
+        vm.prank(terminalStore);
+        (weightReturned, specificationsReturned) = hook.beforePayRecordedWith(beforePayRecordedContext);
+
+        // No hook specifications should be returned.
+        assertEq(specificationsReturned.length, 0);
+
+        // The weight should be returned unchanged.
+        assertEq(weightReturned, tokenCount);
+    }
+
     /// @notice Test the `beforePayRecordedWith` function when the amount to use for the swap is greater than the amount
     /// of tokens sent (should revert).
     function test_beforePayRecordedWith_RevertIfTryingToOverspend(uint256 swapOutCount, uint256 amountIn) public {

--- a/test/Unit.t.sol
+++ b/test/Unit.t.sol
@@ -326,6 +326,35 @@ contract Test_BuybackHook_Unit is Test {
     /// minting
     /// from the terminal.
     function test_beforePayRecordedContext_useTwapNonDeployedPool(uint256 tokenCount) public {
+        vm.etch(address(pool), "");
+        assert(address(pool).code.length == 0);
+
+        tokenCount = bound(tokenCount, 1, type(uint120).max);
+
+        // Set the relevant context.
+        beforePayRecordedContext.weight = tokenCount;
+        beforePayRecordedContext.metadata = "";
+
+        // Return values to catch:
+        JBPayHookSpecification[] memory specificationsReturned;
+        uint256 weightReturned;
+
+        // Test: call `beforePayRecordedWith` - notice we don't mock the pool, as the address should remain empty
+        vm.prank(terminalStore);
+        (weightReturned, specificationsReturned) = hook.beforePayRecordedWith(beforePayRecordedContext);
+
+        // No hook specifications should be returned.
+        assertEq(specificationsReturned.length, 0);
+
+        // The weight should be returned unchanged.
+        assertEq(weightReturned, tokenCount);
+    }
+
+    /// @notice Test `beforePayRecordedWith` with a TWAP but an invalid pool address, which should lead to the payment
+    /// minting from the terminal.
+    function test_beforePayRecordedContext_useTwapInvalidPool(uint256 tokenCount) public {
+        vm.etch(address(pool), "12345678");
+
         tokenCount = bound(tokenCount, 1, type(uint120).max);
 
         // Set the relevant context.

--- a/test/Unit.t.sol
+++ b/test/Unit.t.sol
@@ -322,7 +322,8 @@ contract Test_BuybackHook_Unit is Test {
         assertEq(weightReturned, tokenCount);
     }
 
-    /// @notice Test `beforePayRecordedWith` with a TWAP but a non-deployed pool, which should lead to the payment minting
+    /// @notice Test `beforePayRecordedWith` with a TWAP but a non-deployed pool, which should lead to the payment
+    /// minting
     /// from the terminal.
     function test_beforePayRecordedContext_useTwapNonDeployedPool(uint256 tokenCount) public {
         tokenCount = bound(tokenCount, 1, type(uint120).max);

--- a/test/Unit.t.sol
+++ b/test/Unit.t.sol
@@ -326,6 +326,7 @@ contract Test_BuybackHook_Unit is Test {
     /// minting
     /// from the terminal.
     function test_beforePayRecordedContext_useTwapNonDeployedPool(uint256 tokenCount) public {
+        // The pool address as no bytecode (yet)
         vm.etch(address(pool), "");
         assert(address(pool).code.length == 0);
 
@@ -353,7 +354,10 @@ contract Test_BuybackHook_Unit is Test {
     /// @notice Test `beforePayRecordedWith` with a TWAP but an invalid pool address, which should lead to the payment
     /// minting from the terminal.
     function test_beforePayRecordedContext_useTwapInvalidPool(uint256 tokenCount) public {
+        // Invalid bytecode at the pool address - notice it shouldn't be possible, as we rely on create2 pool address
         vm.etch(address(pool), "12345678");
+        vm.expectRevert();
+        pool.slot0();
 
         tokenCount = bound(tokenCount, 1, type(uint120).max);
 


### PR DESCRIPTION
# Description

- Add a byte code length check (returning a twap of 0 for non deployed pool) as it was reverting even if wrapped in a try/catch
- Add an explicit unit test for the non-deployed and invalid pool cases

## Limitations & risks

- other unknown edge cases

# Check-list
- [x] Tests are covering the new feature
- [x] Code is [natspec'd](https://docs.soliditylang.org/en/v0.8.17/natspec-format.html)
- [x] Code is [linted and formatted](https://docs.soliditylang.org/en/v0.8.17/style-guide.html)
- [x] I have run the test locally (and they pass)
- [x] I have rebased to the latest main commit (and tests still pass)

# Interactions
These changes will impact the following contracts:
- Directly:
Buyback hook
- Indirectly:
Terminal, controller, project token