### PR TITLE
fix: uniswap v3-periphery tag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@exhausted-pigeon/uniswap-v3-forge-quoter": "^1.0.1",
         "@openzeppelin/contracts": "^5.0.2",
         "@uniswap/v3-core": "1.0.2-solc-0.8-simulate",
-        "@uniswap/v3-periphery": "github:uniswap/v3-periphery#1.3"
+        "@uniswap/v3-periphery": "github:uniswap/v3-periphery#1.3.0"
       },
       "devDependencies": {
         "@sphinx-labs/plugins": "^0.32.2"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@exhausted-pigeon/uniswap-v3-forge-quoter": "^1.0.1",
     "@openzeppelin/contracts": "^5.0.2",
     "@uniswap/v3-core": "1.0.2-solc-0.8-simulate",
-    "@uniswap/v3-periphery": "github:uniswap/v3-periphery#1.3"
+    "@uniswap/v3-periphery": "github:uniswap/v3-periphery#1.3.0"
   },
   "devDependencies": {
     "@sphinx-labs/plugins": "^0.32.2"


### PR DESCRIPTION
For an unknown reason, `npm install`ing this package fails with this error (but yarn works):

```
npm error code 1
npm error The git reference could not be found
npm error command git --no-replace-objects checkout 1.3
npm error error: pathspec '1.3' did not match any file(s) known to git
```

I think its because `@uniswap/v2-periphery` doesn't have a `1.3` tag; its specified as `1.3.0`: https://github.com/Uniswap/v3-periphery/releases/tag/v1.3.0

THis PR sets it at 1.3.0